### PR TITLE
Upgrade to 6.8.1

### DIFF
--- a/io.qt.PySide.BaseApp.metainfo.xml
+++ b/io.qt.PySide.BaseApp.metainfo.xml
@@ -10,8 +10,8 @@
         <name>The Qt Company</name>
     </developer>
   <releases>
-    <release version="6.8.0" date="2024-10-10">
-        <url type="details">https://code.qt.io/cgit/pyside/pyside-setup.git/tree/doc/changelogs/changes-6.8.0</url>
+    <release version="6.8.1" date="2024-12-02">
+        <url type="details">https://code.qt.io/cgit/pyside/pyside-setup.git/tree/doc/changelogs/changes-6.8.1</url>
     </release>
   </releases>
 </component>

--- a/io.qt.PySide.BaseApp.yaml
+++ b/io.qt.PySide.BaseApp.yaml
@@ -26,7 +26,7 @@ modules:
     sources:
       - type: git
         url: "https://code.qt.io/pyside/pyside-setup.git"
-        tag: "v6.8.0.2"
+        tag: "v6.8.1"
   - name: polish
     buildsystem: simple
     build-commands:

--- a/python3-requirements.json
+++ b/python3-requirements.json
@@ -7,7 +7,7 @@
             "name": "python3-packaging",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"packaging==24.1\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"packaging==24.1\" --no-build-isolation --ignore-installed"
             ],
             "sources": [
                 {


### PR DESCRIPTION
The issue of a missing symbol was caused because the Kde runtime and the webengine baseapp used Qt 6.8.1 as oppose to PySide6 baseapp which used 6.8.0.2

Closes #11 