### PR TITLE
Upgrade to 6.8.2

### DIFF
--- a/io.qt.PySide.BaseApp.metainfo.xml
+++ b/io.qt.PySide.BaseApp.metainfo.xml
@@ -10,8 +10,8 @@
         <name>The Qt Company</name>
     </developer>
   <releases>
-    <release version="6.8.1" date="2024-12-02">
-        <url type="details">https://code.qt.io/cgit/pyside/pyside-setup.git/tree/doc/changelogs/changes-6.8.1</url>
+    <release version="6.8.2" date="2025-01-31">
+        <url type="details">https://code.qt.io/cgit/pyside/pyside-setup.git/tree/doc/changelogs/changes-6.8.2</url>
     </release>
   </releases>
 </component>

--- a/io.qt.PySide.BaseApp.yaml
+++ b/io.qt.PySide.BaseApp.yaml
@@ -26,7 +26,7 @@ modules:
     sources:
       - type: git
         url: "https://code.qt.io/pyside/pyside-setup.git"
-        tag: "v6.8.1"
+        tag: "v6.8.2"
   - name: polish
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
- The Kde runtime and the webengine baseapp now uses 6.8.2