### PR TITLE
Imrpove cleanup

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -48,6 +48,11 @@ if [ -n "$BASEAPP_REMOVE_WEBENGINE" ] || [ -n "$BASEAPP_REMOVE_PYWEBENGINE" ]; t
   rm -rfv ${FLATPAK_DEST}/libexec/webenginedriver
 fi
 
+# numpy cleanup
+if [ -n "$BASEAPP_DISABLE_NUMPY" ]; then
+  pip uninstall -y numpy
+fi
+
 # webengine baseapp cleanup
 [ -r ${FLATPAK_DEST}/cleanup-BaseApp-QtWebEngine.sh ] &&
   ${FLATPAK_DEST}/cleanup-BaseApp-QtWebEngine.sh

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -3,6 +3,13 @@
 # pyside
 rm -rfv ${FLATPAK_DEST}/bin/pyside6-*
 rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/PySide6/scripts
+rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/PySide6/doc
+
+# python-build
+pip uninstall -y build
+
+# python packging
+pip uninstall -y packaging
 
 # webengine cleanup based on set variables
 if [ -n "$BASEAPP_REMOVE_WEBENGINE" ] || [ -n "$BASEAPP_REMOVE_PYWEBENGINE" ]; then
@@ -22,11 +29,11 @@ if [ -n "$BASEAPP_REMOVE_WEBENGINE" ] || [ -n "$BASEAPP_REMOVE_PYWEBENGINE" ]; t
   rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/PySide6/QtWebEngine{,Core,Quick,Widgets}.abi3.so
   rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/PySide6/QtWebEngine{,Core,Quick,Widgets}.pyi
 
-  # qtpdf
+  # pyside qtpdf
   rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/PyQt6/Qt{,Pdf,PdfWidgets}.abi3.so
   rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/PyQt6/Qt{,Pdf,PdfWidgets}.pyi
 
-  # qtwebview
+  # pyside qtwebview
   rm -rfv ${FLATPAK_DEST}/qml/QtWebView
   rm -rfv ${FLATPAK_DEST}/plugins/webview
   rm -rfv ${FLATPAK_DEST}/lib/${FLATPAK_ARCH}-linux-gnu/libQt*WebView{,Quick}.so*
@@ -46,6 +53,7 @@ if [ -n "$BASEAPP_REMOVE_WEBENGINE" ] || [ -n "$BASEAPP_REMOVE_PYWEBENGINE" ]; t
   rm -rfv ${FLATPAK_DEST}/share/locale/*/qtwebengine_dictionaries
   rm -rfv ${FLATPAK_DEST}/translations/qtwebengine_locales
   rm -rfv ${FLATPAK_DEST}/libexec/webenginedriver
+  rm -rfv ${FLATPAK_DEST}/libexec/QtWebEngineProcess
 fi
 
 # numpy cleanup

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -4,6 +4,50 @@
 rm -rfv ${FLATPAK_DEST}/bin/pyside6-*
 rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/PySide6/scripts
 
+# webengine cleanup based on set variables
+if [ -n "$BASEAPP_REMOVE_WEBENGINE" ] || [ -n "$BASEAPP_REMOVE_PYWEBENGINE" ]; then
+  # krb5
+  rm -rfv ${FLATPAK_DEST}/etc/krb5.conf
+  rm -rfv ${FLATPAK_DEST}/lib/krb5
+  rm -rfv ${FLATPAK_DEST}/lib/lib{com_err,gss{api_krb5,rpc},k5crypto,kadm5{clnt{,_mit},srv{,_mit}},kdb5,krad,krb5{,support},verto}.so*
+  rm -rfv ${FLATPAK_DEST}/share/locale/*/LC_MESSAGES/mit-krb5.mo
+
+  # libevent
+  rm -rfv ${FLATPAK_DEST}/lib/libevent{,_core,_extra,_openssl,_pthreads}*.so*
+
+  # minizip, pciutils, re2, snappy
+  rm -rfv ${FLATPAK_DEST}/lib/lib{minizip,pci,re2,snappy}.so*
+
+  # pyside webengine
+  rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/PySide6/QtWebEngine{,Core,Quick,Widgets}.abi3.so
+  rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/PySide6/QtWebEngine{,Core,Quick,Widgets}.pyi
+
+  # qtpdf
+  rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/PyQt6/Qt{,Pdf,PdfWidgets}.abi3.so
+  rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/PyQt6/Qt{,Pdf,PdfWidgets}.pyi
+
+  # qtwebview
+  rm -rfv ${FLATPAK_DEST}/qml/QtWebView
+  rm -rfv ${FLATPAK_DEST}/plugins/webview
+  rm -rfv ${FLATPAK_DEST}/lib/${FLATPAK_ARCH}-linux-gnu/libQt*WebView{,Quick}.so*
+  rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/PyQt6/QtWebView.abi3.so
+  rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/PyQt6/QtWebView.pyi
+
+  # qtwebengine
+  rm -rfv ${FLATPAK_DEST}/bin/QtWebEngineProcess
+  rm -rfv ${FLATPAK_DEST}/plugins/imageformats
+  rm -rfv ${FLATPAK_DEST}/qml/{QtQuick/Pdf,QtWebEngine}
+  rm -rfv ${FLATPAK_DEST}/lib/${FLATPAK_ARCH}-linux-gnu/libQt*{Pdf{,Quick,Widgets},WebEngine{,Core,Quick{,DelegatesQml},Widgets}}.so*
+  rm -fv ${FLATPAK_DEST}/lib/libQt*{Pdf{,Quick,Widgets},WebEngine{,Core,Quick{,DelegatesQml},Widgets}}.so*
+  rm -rfv ${FLATPAK_DEST}/lib/libQt6WebView*.so*
+  rm -rfv ${FLATPAK_DEST}/qtwebengine_dictionaries
+  rm -rfv ${FLATPAK_DEST}/resources/qtwebengine*.pak
+  rm -rfv ${FLATPAK_DEST}/resources/v8_context_snapshot.bin
+  rm -rfv ${FLATPAK_DEST}/share/locale/*/qtwebengine_dictionaries
+  rm -rfv ${FLATPAK_DEST}/translations/qtwebengine_locales
+  rm -rfv ${FLATPAK_DEST}/libexec/webenginedriver
+fi
+
 # webengine baseapp cleanup
 [ -r ${FLATPAK_DEST}/cleanup-BaseApp-QtWebEngine.sh ] &&
   ${FLATPAK_DEST}/cleanup-BaseApp-QtWebEngine.sh

--- a/io.qt.PySide.BaseApp.yaml
+++ b/io.qt.PySide.BaseApp.yaml
@@ -22,6 +22,7 @@ modules:
       - python3 setup.py build --qtpaths=/usr/bin/qtpaths --ignore-git --parallel=8
         --log-level=verbose --no-qt-tools --flatpak
       - python3 create_wheels.py --build-dir ./build/qfp-*-release
+      - rm -rf ./dist/PySide6_Examples*.whl
       - pip install ./dist/*.whl --prefix=${FLATPAK_DEST}
     sources:
       - type: git


### PR DESCRIPTION
closes #13 

- The cleanup script now introduces variables to conditionally cleanup heavy dependcies like WebEngine and Numpy. This is done by setting the variables `BASEAPP_REMOVE_WEBENGINE`/`BASEAPP_REMOVE_PYWEBENGINE` in the manifest of the application using the PySide Baseapp. Similarly, for Numpy this variable is called `BASEAPP_DISABLE_NUMPY`.
- The PySide6 Examples which were earlier bundled with the baseapp is now removed.
- Futher cleanup by removing non-relevant folders like `doc` and non relevant Python packages like `packaging`, `build`