### PR TITLE
Add PySide6 tools to the BaseApp

### DIFF
--- a/io.qt.PySide.BaseApp.yaml
+++ b/io.qt.PySide.BaseApp.yaml
@@ -20,7 +20,7 @@ modules:
     buildsystem: simple
     build-commands:
       - python3 setup.py build --qtpaths=/usr/bin/qtpaths --ignore-git --parallel=8
-        --log-level=verbose --no-qt-tools --flatpak
+        --log-level=verbose --flatpak
       - python3 create_wheels.py --build-dir ./build/qfp-*-release
       - rm -rf ./dist/PySide6_Examples*.whl
       - pip install ./dist/*.whl --prefix=${FLATPAK_DEST}


### PR DESCRIPTION
- This makes tools like pyside6-uic, pyside6-rcc, pyside6-lupdate etc. available in the baseapp environment, and support using the BaseApp for developing PySide6 applications.