### PR TITLE
Bundle LLVM 21 libraries for shiboken6 runtime support

### DIFF
--- a/io.qt.PySide.BaseApp.yaml
+++ b/io.qt.PySide.BaseApp.yaml
@@ -24,6 +24,15 @@ modules:
       - python3 create_wheels.py --build-dir ./build/qfp-*-release
       - rm -rf ./dist/PySide6_Examples*.whl
       - pip install ./dist/*.whl --prefix=${FLATPAK_DEST}
+      - install -Dm755 /usr/lib/sdk/llvm21/lib/libLLVM.so.21.1 ${FLATPAK_DEST}/lib/
+      - install -Dm755 /usr/lib/sdk/llvm21/lib/libclang-cpp.so.21.1 ${FLATPAK_DEST}/lib/
+      - install -Dm755 /usr/lib/sdk/llvm21/lib/libclang.so.21.1 ${FLATPAK_DEST}/lib/
+      - ln -s libLLVM.so.21.1 ${FLATPAK_DEST}/lib/libLLVM.so.21
+      - ln -s libLLVM.so.21.1 ${FLATPAK_DEST}/lib/libLLVM.so
+      - ln -s libclang-cpp.so.21.1 ${FLATPAK_DEST}/lib/libclang-cpp.so.21
+      - ln -s libclang-cpp.so.21.1 ${FLATPAK_DEST}/lib/libclang-cpp.so
+      - ln -s libclang.so.21.1 ${FLATPAK_DEST}/lib/libclang.so.21
+      - ln -s libclang.so.21.1 ${FLATPAK_DEST}/lib/libclang.so
     sources:
       - type: git
         url: "https://code.qt.io/pyside/pyside-setup.git"


### PR DESCRIPTION
Fixes #33

The shiboken6 generator was failing at runtime unable to load libclang 21 shared libraries.

This occurred because shiboken6 was built against LLVM 21 from the SDK extension (org.freedesktop.Sdk.Extension.llvm21), but these libraries are not available in the runtime environment.

In this patch, we bundle libLLVM.so.21.1, libclang-cpp.so.21.1, and libclang.so.21.1 from the LLVM 21 SDK extension into the BaseApp, along with appropriate symlinks to fix this issues.