### PR TITLE
Update to 6.10.3

### DIFF
--- a/io.qt.PySide.BaseApp.metainfo.xml
+++ b/io.qt.PySide.BaseApp.metainfo.xml
@@ -10,8 +10,8 @@
         <name>The Qt Company</name>
     </developer>
   <releases>
-    <release version="6.10.2" date="2026-02-02">
-        <url type="details">https://code.qt.io/cgit/pyside/pyside-setup.git/tree/doc/changelogs/changes-6.10.2</url>
+    <release version="6.10.3" date="2026-05-23">
+        <url type="details">https://code.qt.io/cgit/pyside/pyside-setup.git/tree/doc/changelogs/changes-6.10.3</url>
     </release>
   </releases>
 </component>

--- a/io.qt.PySide.BaseApp.yaml
+++ b/io.qt.PySide.BaseApp.yaml
@@ -36,8 +36,8 @@ modules:
     sources:
       - type: git
         url: "https://code.qt.io/pyside/pyside-setup.git"
-        tag: "v6.10.2"
-        commit: "057cda38d369d042c59fd48544398cb917540718"
+        tag: "v6.10.3"
+        commit: "863e6b6e6269fbd401db06e2066119b9014fcf0d"
   - name: polish
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
Upgrade PySide6 version from 6.10.2 to 6.10.3 to match https://invent.kde.org/packaging/flatpak-kde-runtime/-/merge_requests/366

Apps relying on the PySide6 base app tend to break when the versions of the KDE runtime and the PySide6 base app run out of sync, see https://github.com/flathub/net.davidotek.pupgui2/issues/47 for example.

---

Is this base app actively maintained? This is already the second time it runs out of sync (https://github.com/flathub/io.qt.PySide.BaseApp/pull/36) and breaks apps on Flathub: https://github.com/flathub/net.davidotek.pupgui2/pull/43, https://github.com/flathub/io.github.qcanvas.QCanvasApp/pull/23, https://github.com/flathub/org.torproject.torbrowser-launcher/issues/180
I think it is important that the versions stay in sync since PySide6 seems to rely on some private API function where the API/ABI seems to be unstable...

---

**I have created a discussion about the ABI mismatch issue in general in https://github.com/flathub/io.qt.PySide.BaseApp/issues/44**